### PR TITLE
Update download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ The Hubs Architecture Kit is one example of configurable pieces that can be used
 
 # Download
 
-In order to download the source files for the kit you will need the [Github Desktop client](https://desktop.github.com/), or [Git-LFS](https://git-lfs.github.com/) if you are using the command line. Then clone the repository.
+This repository uses [Git LFS](https://git-lfs.com/).
+
+If you just want the files to use, please [download them from here](https://drive.google.com/drive/folders/1n8pwe5QFF5kbb_Qed9UVkeB0svdRZTrT?usp=sharing).
+
+**Contributors:**
+If you want to contribute to the repository, you will need to have Git LFS installed before cloning the repository (don't forget to run `git lfs install` once you've installed it).
 
 # License
 All assets in this repository are licensed with CC-BY 2.0.


### PR DESCRIPTION
Add link to downloadable assets on the Hubs Foundation's Google Drive.
Add note for contributors that they will need to install Git LFS in order to clone the repository.

GitHub's LFS downloads are expensive, so a copy of the files has been provided on the Hubs Foundation's Google Drive for people to download to help save bandwidth.